### PR TITLE
City state api

### DIFF
--- a/src/utils/getCoordinates.test.ts
+++ b/src/utils/getCoordinates.test.ts
@@ -1,0 +1,39 @@
+import {getCityStateCoordinates, LocationData} from '../utils/getCoordinates';
+import {Coordinates} from './getClosestPoint';
+
+describe('getCityStateCoordinates', () => {
+    const bend: Coordinates = {lat: 44.05817280000002, long: -121.31530959999996};
+    const eugene: Coordinates = {lat: 44.05206910000004, long: -123.08675359999994};
+
+    test("Bend's coordinates are correct", async () => {
+        const data: LocationData = await getCityStateCoordinates("bend+'or");
+        expect(data.hasError).toBe(false);
+        expect(data.errorMessage).toBe('');
+        expect(data.latitude).toEqual(bend.lat);
+        expect(data.longitude).toEqual(bend.long);
+    });
+
+    test("Eugenes's coordinates are correct", async () => {
+        const data: LocationData = await getCityStateCoordinates("eugene+'or");
+        expect(data.hasError).toBe(false);
+        expect(data.errorMessage).toBe('');
+        expect(data.latitude).toEqual(eugene.lat);
+        expect(data.longitude).toEqual(eugene.long);
+    });
+
+    test("Error message for city that doesn't exist", async () => {
+        const data: LocationData = await getCityStateCoordinates("fjklds+'or");
+        expect(data.hasError).toBe(true);
+        expect(data.errorMessage).toBe('Error in API response');
+        expect(data.latitude).toBe(null);
+        expect(data.longitude).toBe(null);
+    });
+
+    test("Error message for state that doesn't exist", async () => {
+        const data: LocationData = await getCityStateCoordinates("salem+'mk");
+        expect(data.hasError).toBe(true);
+        expect(data.errorMessage).toBe('Error in API response');
+        expect(data.latitude).toBe(null);
+        expect(data.longitude).toBe(null);
+    });
+});

--- a/src/utils/getCoordinates.ts
+++ b/src/utils/getCoordinates.ts
@@ -1,0 +1,51 @@
+interface CityStateApiData {
+    records: { 
+        fields: { 
+            geo_point_2d: number[]
+        }
+    } [];
+}
+
+// if error from API: set hasError and enter string for errorMessage
+// if no error from API: set latitudea and longitude to appropriate values
+export interface LocationData {
+    hasError: boolean,
+    errorMessage: string,
+    latitude: number | null,
+    longitude: number | null
+}
+
+// gets latitude and longitude for a city-state pair (for example, Eugene, OR)
+// if API returns an error, the LocationData object will have hasError = true
+export async function getCityStateCoordinates(cityState: string): Promise<LocationData> {
+    const cityApiStr = 'https://public.opendatasoft.com/api/records/1.0/search/?dataset=cities-and-towns-of-the-united-states&q='
+    const data = await fetch(cityApiStr + cityState, {
+        method: 'GET',
+    });
+
+    const json: CityStateApiData = await data.json();
+    console.log(json);
+
+    // starts with error message--change if API returns valid response
+    let locationData: LocationData = {
+        hasError: true,
+        errorMessage: 'Error in API response',
+        latitude: null,
+        longitude: null
+    };
+
+    try {
+        if(json.records[0].fields.geo_point_2d[0] && json.records[0].fields.geo_point_2d[1]) {
+            locationData =  {
+                hasError: false,
+                errorMessage: '',
+                latitude: json.records[0].fields.geo_point_2d[0],
+                longitude: json.records[0].fields.geo_point_2d[1]
+            };
+        }
+    } catch(error){
+        console.log(error);
+    }
+
+    return locationData;
+}


### PR DESCRIPTION
If user enters city-state pair into text box, it now calls Opendatasoft's "Cities and Towns of the United States" API, (see https://public.opendatasoft.com/explore/dataset/cities-and-towns-of-the-united-states/table).

I moved the API call logic to a separate file, getCoordinates.ts, in the util folder. I also added some tests.