### PR TITLE
Remove api call button

### DIFF
--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -28,90 +28,26 @@ interface FrostDatesJulian {
   severe: number
 }
 
-class DataState {
-  //Julian Day number of fall and spring frost severities
-  @observable
-  fall24 = 0
-  setFall24 = (fall24: number) => {
-      this.fall24 = fall24
-  }
-  @observable
-  fall28 = 0
-  setFall28 = (fall28: number) => {
-      this.fall28 = fall28
-  }
-  @observable
-  fall32 = 0
-  setFall32 = (fall32: number) => {
-      this.fall32 = fall32
-  }
-  @observable
-  spr24 = 0
-  setSpr24 = (spr24: number) => {
-      this.spr24 = spr24
-  }
-  @observable
-  spr28 = 0
-  setSpr28 = (spr28: number) => {
-      this.spr28 = spr28
-  }
-  @observable
-  spr32 = 0
-  setSpr32 = (spr32: number) => {
-      this.spr32 = spr32
-  }
-
-  //Date of fall and spring frost severities
-  @observable
-  fall24Date: Date = new Date(new Date().getFullYear(), 0, 1)
-  setfall24Date = (fall24Date: Date) => {
-      this.fall24Date = fall24Date
-  }
-  @observable
-  fall28Date: Date = new Date(new Date().getFullYear(), 0, 1)
-  setfall28Date = (fall28Date: Date) => {
-      this.fall28Date = fall28Date
-  }
-  @observable
-  fall32Date: Date = new Date(new Date().getFullYear(), 0, 1)
-  setfall32Date = (fall32Date: Date) => {
-      this.fall32Date = fall32Date
-  }
-
-  @observable
-  spr24Date: Date = new Date(new Date().getFullYear(), 0, 1)
-  setspr24Date = (spr24Date: Date) => {
-      this.spr24Date = spr24Date
-  }
-  @observable
-  spr28Date: Date = new Date(new Date().getFullYear(), 0, 1)
-  setspr28Date = (spr28Date: Date) => {
-      this.spr28Date = spr28Date
-  }
-  @observable
-  spr32Date: Date = new Date(new Date().getFullYear(), 0, 1)
-  setspr32Date = (spr32Date: Date) => {
-      this.spr32Date = spr32Date
-  }
-  //climate normal station ID number
-  @observable
-  stationID: string = "Station ID:"
-  setID = (stationID: string) => {
-      this.stationID = stationID
-  }
+interface FrostDates {
+  light: Date,
+  moderate: Date,
+  severe: Date
 }
 
 const ResultsPage: React.FC<ContainerProps> = ({match, history}) => { 
   const [stationID, setStation] = useState<string>(match.params.id);
-  const [springFrostDatesJulian, setSpringFrostDatesJulian] = useState<FrostDatesJulian>({light: 0, moderate: 0, severe: 0});
-  const [fallFrostDatesJulian, setfallFrostDatesJulian] = useState<FrostDatesJulian>({light: 0, moderate: 0, severe: 0});
-  const state = React.useRef(new DataState()).current
+  const [springFrostJulian, setSpringFrostJulian] = useState<FrostDatesJulian>({light: 0, moderate: 0, severe: 0});
+  const [fallFrostJulian, setFallFrostJulian] = useState<FrostDatesJulian>({light: 0, moderate: 0, severe: 0});
+  const [springFrostDates, setSpringFrostDates] = useState<FrostDates>({light: new Date(new Date().getFullYear(), 0, 1), moderate: new Date(new Date().getFullYear(), 0, 1), severe: new Date(new Date().getFullYear(), 0, 1)});
+  const [fallFrostDates, setFallFrostDates] = useState<FrostDates>({light: new Date(), moderate: new Date(), severe: new Date()});
+
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<DataError>({ showError: false });
   let myData: { results: { value: any; }[]; };
   const apiStr = 'https://www.ncdc.noaa.gov/cdo-web/api/v2/data?datasetid=NORMAL_ANN&datatypeid=ANN-TMIN-PRBLST-T24FP90&datatypeid=ANN-TMIN-PRBLST-T28FP90&datatypeid=ANN-TMIN-PRBLST-T32FP90&datatypeid=ANN-TMIN-PRBFST-T24FP90&datatypeid=ANN-TMIN-PRBFST-T28FP90&datatypeid=ANN-TMIN-PRBFST-T32FP90&startdate=2010-01-01&enddate=2010-01-01';
 
-  // must declare function INSIDE of useEffect to avoid error concerning return of Promise in callback function
+  // fetches frost dates after station ID updates
+  // must declare async function INSIDE of useEffect to avoid error concerning return of Promise in callback function
   useEffect( () => {
     async function getData () {
       setLoading(true);
@@ -127,38 +63,38 @@ const ResultsPage: React.FC<ContainerProps> = ({match, history}) => {
       .then(data => {
           myData = data;
           console.log(`my data: `, myData.results)
-          setfallFrostDatesJulian({
+          setFallFrostJulian({
             severe: myData.results[0].value,
             moderate: myData.results[1].value,
             light: myData.results[2].value
           });
-          setSpringFrostDatesJulian({
+          setSpringFrostJulian({
             severe: myData.results[3].value,
             moderate: myData.results[4].value,
             light: myData.results[5].value
           });
-          // state.setFall24(myData.results[0].value);
-          // state.setFall28(myData.results[1].value);
-          // state.setFall32(myData.results[2].value);
-          // state.setSpr24(myData.results[3].value);
-          // state.setSpr28(myData.results[4].value);
-          // state.setSpr32(myData.results[5].value);
-          
-          // //fix leap years
-          // var isLeap = new Date(THIS_YEAR, 1, 29).getMonth() == 1
-          // if(isLeap) {
-          //     var i;
-          //     for(i = 0; i < myData.results.length; i++ ) {
-          //         if(myData.results[i].value > 59) { myData.results[i].value += 1}
-          //     }
-          // }
-          // state.setfall24Date(momentToDate(moment([2020]).add(myData.results[0].value - 1, 'd')))
-          // state.setfall28Date(momentToDate(moment([2020]).add(myData.results[1].value - 1, 'd')))
-          // state.setfall32Date(momentToDate(moment([2020]).add(myData.results[2].value - 1, 'd')))
-          // state.setspr24Date(momentToDate(moment([2020]).add(myData.results[3].value - 1, 'd')))
-          // state.setspr28Date(momentToDate(moment([2020]).add(myData.results[4].value - 1, 'd')))
-          // state.setspr32Date(momentToDate(moment([2020]).add(myData.results[5].value - 1, 'd')))
-          
+
+          //fix leap years
+          var isLeap = new Date(THIS_YEAR, 1, 29).getMonth() == 1
+          if(isLeap) {
+              var i;
+              for(i = 0; i < myData.results.length; i++ ) {
+                  if(myData.results[i].value > 59) { myData.results[i].value += 1}
+              }
+          }
+
+          setFallFrostDates({
+            light: momentToDate(moment([2020]).add(myData.results[2].value - 1, 'd')),
+            moderate: momentToDate(moment([2020]).add(myData.results[1].value - 1, 'd')),
+            severe: momentToDate(moment([2020]).add(myData.results[0].value - 1, 'd'))
+          });
+
+          setSpringFrostDates({
+            light: momentToDate(moment([2020]).add(myData.results[5].value - 1, 'd')),
+            moderate: momentToDate(moment([2020]).add(myData.results[4].value - 1, 'd')),
+            severe: momentToDate(moment([2020]).add(myData.results[3].value - 1, 'd'))
+          });
+
           setLoading(false);
       })
       .catch((error) => {
@@ -193,25 +129,16 @@ const ResultsPage: React.FC<ContainerProps> = ({match, history}) => {
               message={error.message}
               duration={3000}
           />
-          {/* <IonButton color="primary" onClick={getData}>Make API Call</IonButton> */}
+
           <br/> Station: {match.params.id} 
               <h4>Spring Freeze Dates</h4>
-              <h5>Last Severe Freeze: {state.spr24} - {state.spr24Date.toDateString()}</h5>
-              <h5>Last Moderate Freeze: {state.spr28} - {state.spr28Date.toDateString()}</h5>
-              <h5>Last Light Freeze: {state.spr32} - {state.spr32Date.toDateString()}</h5>
+              <h5>Last Severe Freeze: {springFrostJulian.severe} - {springFrostDates.severe.toDateString()}</h5>
+              <h5>Last Moderate Freeze: {springFrostJulian.moderate} - {springFrostDates.moderate.toDateString()}</h5>
+              <h5>Last Light Freeze: {springFrostJulian.light} - {springFrostDates.light.toDateString()}</h5>
               <h4>Fall Freeze Dates</h4>
-              <h5>First Severe Freeze: {state.fall24} - {state.fall24Date.toDateString()}</h5>
-              <h5>First Moderate Freeze: {state.fall28} - {state.fall28Date.toDateString()}</h5>
-              <h5>First Light Freeze: {state.fall32} - {state.fall32Date.toDateString()}</h5>
-
-              <h4>Spring Freeze Dates</h4>
-              <h5>Last Severe Freeze: {springFrostDatesJulian.severe}</h5>
-              <h5>Last Moderate Freeze: {springFrostDatesJulian.moderate}</h5>
-              <h5>Last Light Freeze: {springFrostDatesJulian.light}</h5>
-              <h4>Fall Freeze Dates</h4>
-              <h5>First Severe Freeze: {fallFrostDatesJulian.severe}</h5>
-              <h5>First Moderate Freeze: {fallFrostDatesJulian.moderate}</h5>
-              <h5>First Light Freeze: {fallFrostDatesJulian.light}</h5>
+              <h5>First Severe Freeze: {fallFrostJulian.severe} - {fallFrostDates.severe.toDateString()}</h5>
+              <h5>First Moderate Freeze: {fallFrostJulian.moderate} - {fallFrostDates.moderate.toDateString()}</h5>
+              <h5>First Light Freeze: {fallFrostJulian.light} - {fallFrostDates.light.toDateString()}</h5>
       </div>
       </IonContent>
     </IonPage>

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -103,14 +103,13 @@ class DataState {
 
 const ResultsPage: React.FC<ContainerProps> = ({match, history}) => { 
   const [stationID, setStation] = useState<string>(match.params.id);
+  const [springFrostDatesJulian, setSpringFrostDatesJulian] = useState<FrostDatesJulian>({light: 0, moderate: 0, severe: 0});
+  const [fallFrostDatesJulian, setfallFrostDatesJulian] = useState<FrostDatesJulian>({light: 0, moderate: 0, severe: 0});
   const state = React.useRef(new DataState()).current
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<DataError>({ showError: false });
   let myData: { results: { value: any; }[]; };
   const apiStr = 'https://www.ncdc.noaa.gov/cdo-web/api/v2/data?datasetid=NORMAL_ANN&datatypeid=ANN-TMIN-PRBLST-T24FP90&datatypeid=ANN-TMIN-PRBLST-T28FP90&datatypeid=ANN-TMIN-PRBLST-T32FP90&datatypeid=ANN-TMIN-PRBFST-T24FP90&datatypeid=ANN-TMIN-PRBFST-T28FP90&datatypeid=ANN-TMIN-PRBFST-T32FP90&startdate=2010-01-01&enddate=2010-01-01';
-  //let stationID = match.params.id;
-  //let stationStr = '&stationid=GHCND:' + stationID;
-  //getData();
 
   // must declare function INSIDE of useEffect to avoid error concerning return of Promise in callback function
   useEffect( () => {
@@ -128,27 +127,37 @@ const ResultsPage: React.FC<ContainerProps> = ({match, history}) => {
       .then(data => {
           myData = data;
           console.log(`my data: `, myData.results)
-          state.setFall24(myData.results[0].value);
-          state.setFall28(myData.results[1].value);
-          state.setFall32(myData.results[2].value);
-          state.setSpr24(myData.results[3].value);
-          state.setSpr28(myData.results[4].value);
-          state.setSpr32(myData.results[5].value);
+          setfallFrostDatesJulian({
+            severe: myData.results[0].value,
+            moderate: myData.results[1].value,
+            light: myData.results[2].value
+          });
+          setSpringFrostDatesJulian({
+            severe: myData.results[3].value,
+            moderate: myData.results[4].value,
+            light: myData.results[5].value
+          });
+          // state.setFall24(myData.results[0].value);
+          // state.setFall28(myData.results[1].value);
+          // state.setFall32(myData.results[2].value);
+          // state.setSpr24(myData.results[3].value);
+          // state.setSpr28(myData.results[4].value);
+          // state.setSpr32(myData.results[5].value);
           
-          //fix leap years
-          var isLeap = new Date(THIS_YEAR, 1, 29).getMonth() == 1
-          if(isLeap) {
-              var i;
-              for(i = 0; i < myData.results.length; i++ ) {
-                  if(myData.results[i].value > 59) { myData.results[i].value += 1}
-              }
-          }
-          state.setfall24Date(momentToDate(moment([2020]).add(myData.results[0].value - 1, 'd')))
-          state.setfall28Date(momentToDate(moment([2020]).add(myData.results[1].value - 1, 'd')))
-          state.setfall32Date(momentToDate(moment([2020]).add(myData.results[2].value - 1, 'd')))
-          state.setspr24Date(momentToDate(moment([2020]).add(myData.results[3].value - 1, 'd')))
-          state.setspr28Date(momentToDate(moment([2020]).add(myData.results[4].value - 1, 'd')))
-          state.setspr32Date(momentToDate(moment([2020]).add(myData.results[5].value - 1, 'd')))
+          // //fix leap years
+          // var isLeap = new Date(THIS_YEAR, 1, 29).getMonth() == 1
+          // if(isLeap) {
+          //     var i;
+          //     for(i = 0; i < myData.results.length; i++ ) {
+          //         if(myData.results[i].value > 59) { myData.results[i].value += 1}
+          //     }
+          // }
+          // state.setfall24Date(momentToDate(moment([2020]).add(myData.results[0].value - 1, 'd')))
+          // state.setfall28Date(momentToDate(moment([2020]).add(myData.results[1].value - 1, 'd')))
+          // state.setfall32Date(momentToDate(moment([2020]).add(myData.results[2].value - 1, 'd')))
+          // state.setspr24Date(momentToDate(moment([2020]).add(myData.results[3].value - 1, 'd')))
+          // state.setspr28Date(momentToDate(moment([2020]).add(myData.results[4].value - 1, 'd')))
+          // state.setspr32Date(momentToDate(moment([2020]).add(myData.results[5].value - 1, 'd')))
           
           setLoading(false);
       })
@@ -194,6 +203,15 @@ const ResultsPage: React.FC<ContainerProps> = ({match, history}) => {
               <h5>First Severe Freeze: {state.fall24} - {state.fall24Date.toDateString()}</h5>
               <h5>First Moderate Freeze: {state.fall28} - {state.fall28Date.toDateString()}</h5>
               <h5>First Light Freeze: {state.fall32} - {state.fall32Date.toDateString()}</h5>
+
+              <h4>Spring Freeze Dates</h4>
+              <h5>Last Severe Freeze: {springFrostDatesJulian.severe}</h5>
+              <h5>Last Moderate Freeze: {springFrostDatesJulian.moderate}</h5>
+              <h5>Last Light Freeze: {springFrostDatesJulian.light}</h5>
+              <h4>Fall Freeze Dates</h4>
+              <h5>First Severe Freeze: {fallFrostDatesJulian.severe}</h5>
+              <h5>First Moderate Freeze: {fallFrostDatesJulian.moderate}</h5>
+              <h5>First Light Freeze: {fallFrostDatesJulian.light}</h5>
       </div>
       </IonContent>
     </IonPage>


### PR DESCRIPTION
Frost dates now load automatically without having to click the API call button. I also refactored the observables for frost dates into React state variables.

Known issues from looking up frost dates using the JSON station list:
- Light frost dates are always -444
- The nearest stations to many locations don't seem to have data