### PR TITLE
iOS: smaller title text; icons are dark

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,11 +42,18 @@ ion-title {
     text-align: center;
     color: var(--ion-color-light);
     font-family: var(--title-font);
-    font-size: 1.6rem;
     padding: 0;
     margin: 0;
     width: 100%;
     height: 100%;
+}
+
+.md ion-title {
+    font-size: 1.6rem;
+}
+
+.ios ion-title {
+    font-size: 1.3rem;
 }
 
 .app-title-button {

--- a/src/App.css
+++ b/src/App.css
@@ -89,6 +89,7 @@ ion-back-button {
 
 .app-icon {
     font-size: 1.8rem;
+    color: var(--ion-color-dark);
 }
 
 .app-page-container {


### PR DESCRIPTION
- Decreased title font size on iOS, based on Andrew's testing on an iPhone 11 emulator in Xcode
- Sets icons to dark color (they had been default orange color in iOS emulator)