### PR TITLE
Splash config

### DIFF
--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -6,10 +6,12 @@
   "webDir": "build",
   "plugins": {
     "SplashScreen": {
-      "backgroundColor:": "#3064b8",
+      "backgroundColor:": "#D73F09",
       "splashFullScreen": true,
       "splashImmersive": true,
-      "autoHide": false
+      "launchAutoHide": false,
+      "androidScaleType": "CENTER_CROP",
+      "showSpinner": true
     }
   },
   "cordova": {}

--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -7,9 +7,6 @@
   "plugins": {
     "SplashScreen": {
       "backgroundColor:": "#D73F09",
-      "splashFullScreen": true,
-      "splashImmersive": true,
-      "launchAutoHide": false,
       "androidScaleType": "CENTER_CROP",
       "showSpinner": true
     }

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -6,10 +6,12 @@
   "webDir": "build",
   "plugins": {
     "SplashScreen": {
-      "backgroundColor:": "#3064b8",
+      "backgroundColor:": "#D73F09",
       "splashFullScreen": true,
       "splashImmersive": true,
-      "autoHide": false
+      "launchAutoHide": false,
+      "androidScaleType": "CENTER_CROP",
+      "showSpinner": true
     }
   },
   "cordova": {}

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -7,9 +7,6 @@
   "plugins": {
     "SplashScreen": {
       "backgroundColor:": "#D73F09",
-      "splashFullScreen": true,
-      "splashImmersive": true,
-      "launchAutoHide": false,
       "androidScaleType": "CENTER_CROP",
       "showSpinner": true
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,11 +23,8 @@ import '@ionic/react/css/display.css';
 
 /* Theme variables */
 import './theme/variables.css';
-const { SplashScreen } = Plugins;
 
 const App: React.FC = () => {
-  SplashScreen.hide();
-
   return(
     <IonApp>
       <IonReactRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,12 +25,10 @@ import '@ionic/react/css/display.css';
 import './theme/variables.css';
 const { SplashScreen } = Plugins;
 
-
 const App: React.FC = () => {
-  SplashScreen.show();
-    
+  SplashScreen.hide();
+
   return(
-    
     <IonApp>
       <IonReactRouter>
         <IonRouterOutlet>


### PR DESCRIPTION
- Splash shows only on first load of dashboard page
- Added spinner
- Removed full screen and immersive options: I think the splash screen loads more smoothly now
- Splash doesn't look distorted on Android anymore (at least for me!)