### PR TITLE
Reduce number of state variables

### DIFF
--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -4,9 +4,6 @@ import { IonButton, IonLoading, IonToast } from '@ionic/react';
 import { getElevation } from '../utils/getUserElevation';
 
 interface DeviceLocationProps {
-    initialLat: number | null;
-    initialLong: number | null;
-    initialElev: number | null;
     onSubmit: (homeLat: number, homeLong: number, homeElev: number) => void;
 }
 
@@ -24,12 +21,6 @@ const DeviceLocation: React.FC<DeviceLocationProps> = (props: DeviceLocationProp
   let lat: number | null = 0;
   let long: number | null = 0;
   let elev: number | null = 0;
-
-  React.useEffect(() => {
-    lat = props.initialLat;
-    long = props.initialLong;
-    elev = props.initialElev;
-  }, [props.initialLat, props.initialLong, props.initialElev]);
 
   const getLocation = async () => {
     const options = {  //Device GPS location settings

--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Geolocation, Geoposition } from '@ionic-native/geolocation/ngx';
 import { IonButton, IonLoading, IonToast } from '@ionic/react';
-import { observable } from 'mobx';
 import { getElevation } from '../utils/getUserElevation';
 
 interface DeviceLocationProps {
@@ -9,64 +8,55 @@ interface DeviceLocationProps {
     initialLong: number | null;
     initialElev: number | null;
     onSubmit: (homeLat: number, homeLong: number, homeElev: number) => void;
- }
+}
+
 interface LocationError {
     showError: boolean;
     message?: string;
 }
-class DeviceData {
-    @observable
-    lat: any = ''
-    setLat = (lat: any) => {
-      this.lat = lat;
-    }
-    @observable
-    long: any = ''
-    setLong = (long: any) => {
-      this.long = long;
-    }
-    @observable
-    elev: any = ''
-    setElev = (elev: any) => {
-      this.elev = elev;
-    }
-}
+
 const DeviceLocation: React.FC<DeviceLocationProps> = (props: DeviceLocationProps) => {
-  const state = React.useRef(new DeviceData()).current;
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<LocationError>({ showError: false });
   const [position, setPosition] = useState<Geoposition>();
   const geolocation = new Geolocation();
 
+  let lat: number | null = 0;
+  let long: number | null = 0;
+  let elev: number | null = 0;
+
   React.useEffect(() => {
-    state.setLat(props.initialLat);
-    state.setLong(props.initialLong);
-    state.setElev(props.initialElev);
-  }, [props.initialLat, props.initialLong, props.initialElev, state]);
+    lat = props.initialLat;
+    long = props.initialLong;
+    elev = props.initialElev;
+  }, [props.initialLat, props.initialLong, props.initialElev]);
 
   const getLocation = async () => {
     const options = {  //Device GPS location settings
       enableHighAccuracy: true,
       timeout: 8000
     };
+
     setLoading(true);
+
     try { //use the device geolocation to get coordinates and possibly elevation
       const position = await geolocation.getCurrentPosition(options);
       setPosition(position);
       setLoading(false);
       setError({ showError: false });
-      state.setLat(position.coords.latitude);
-      state.setLong(position.coords.longitude);
-      //check for evelvation from device
-            
-      if(!position.coords.altitude) { //if no elevation from device, call the separate getElevation function
-        const apiElev = await getElevation(state.lat, state.long);
-        state.setElev(apiElev.elevation);
+      lat = position.coords.latitude;
+      long = position.coords.longitude;
+      
+      // get user's elevation: if none from device, call the API
+      if(!position.coords.altitude) {
+        const apiElev = await getElevation(lat, long);
+        elev = apiElev;
       }
       else { //otherwise, use device's location
-        state.setElev(position.coords.altitude);
+        elev = position.coords.altitude;
       }
-      props.onSubmit(state.lat, state.long, state.elev);
+
+      props.onSubmit(lat, long, elev || 0);
     } catch (e) {
       let msg = e.message;
       if(msg === 'Timeout expired') {msg += '. Make sure your device location service is enabled.';}

--- a/src/components/TextEntry.tsx
+++ b/src/components/TextEntry.tsx
@@ -21,16 +21,6 @@ class EntryData {
   setText = (textEntry: any) => {
     this.textEntry = textEntry;
   }
-  @observable
-  cityName: any = ''
-  setCityName = (cityName: any) => {
-    this.cityName = cityName;
-  }
-  @observable
-  stateCode: any = ''
-  setStateCode = (stateCode: any) => {
-    this.stateCode = stateCode;
-  }
 }
 const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => { 
   const state = React.useRef(new EntryData()).current;
@@ -39,9 +29,9 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
   const [error, setError] = useState<DataError>({ showError: false });
   
   //called when the text entry is determined to be a zip code
-  const getZipCodeData = async () => {
+  const getZipCodeData = async (zip: string) => {
     setLoading(true);
-    const locationData: LocationData = await getZipCoordinates(state.textEntry); //gets the lat/long associated with this zipcode
+    const locationData: LocationData = await getZipCoordinates(zip); //gets the lat/long associated with this zipcode
     if (locationData.hasError) {
       console.log(locationData.errorMessage);
       alert('No results found for your entry. Please check the validity of your five digit zip code.');
@@ -51,10 +41,11 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
     }
     setLoading(false);
   };
+
   //called when the text entry is determined to be a city, state
-  const getCityStateData = async () => {
+  const getCityStateData = async (cityName: string, stateCode: string) => {
     setLoading(true);
-    const locationData: LocationData = await getCityStateCoordinates(state.textEntry, state.cityName.toUpperCase(), state.stateCode.toUpperCase());
+    const locationData: LocationData = await getCityStateCoordinates(state.textEntry, cityName.toUpperCase(), stateCode.toUpperCase());
         
     if (locationData.hasError) {
       console.log(locationData.errorMessage);
@@ -65,6 +56,7 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
     }
     setLoading(false);
   };
+
   //perform input validation on the user entered text and then determine if it is a zipcode or city, state
   const getValid = (data: any) => {
     state.setText(data.text);
@@ -85,7 +77,7 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
         }
       } //get the city name and set state variable.
       for(let i = 0; i < idx; i++) { buildCityName += state.textEntry.charAt(i); }
-      state.setCityName(buildCityName);
+
       //remove spaces after comma
       for(let i = idx + 1; i < state.textEntry.length; i++) {
         if(state.textEntry.charAt(i) === ' ') {
@@ -95,15 +87,15 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
         // add the character to the state code
         else { buildStateCode += state.textEntry.charAt(i).toUpperCase(); }
       }
-      state.setStateCode(buildStateCode);
     }
+    
     //determine if the entry is a city/state pair
     if(regExp.test(state.textEntry) && commaCount === 1) {
       state.setText(state.textEntry.replace(/,/g, ',+\''));
-      getCityStateData();
+      getCityStateData(buildCityName, buildStateCode);
     }
     //determine if entry is a valid zip code
-    else if(!(isNaN(state.textEntry)) && state.textEntry.length === 5) { getZipCodeData(); }
+    else if(!(isNaN(state.textEntry)) && state.textEntry.length === 5) { getZipCodeData(state.textEntry); }
     //check for more than two characters after comma
     else {alert('Entry is invalid, please try again. You must use the two letter postal abbreviation for the state.');}
   };

--- a/src/components/TextEntry.tsx
+++ b/src/components/TextEntry.tsx
@@ -22,21 +22,6 @@ class EntryData {
     this.textEntry = textEntry;
   }
   @observable
-  lat: any = ''
-  setLat = (lat: any) => {
-    this.lat = lat;
-  }
-  @observable
-  long: any = ''
-  setLong = (long: any) => {
-    this.long = long;
-  }
-  @observable
-  elev: any = ''
-  setElev = (elev: any) => {
-    this.elev = elev;
-  }
-  @observable
   cityName: any = ''
   setCityName = (cityName: any) => {
     this.cityName = cityName;
@@ -52,7 +37,7 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
   const { control, handleSubmit } = useForm();
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<DataError>({ showError: false });
-    ;
+  
   //called when the text entry is determined to be a zip code
   const getZipCodeData = async () => {
     setLoading(true);
@@ -61,11 +46,8 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
       console.log(locationData.errorMessage);
       alert('No results found for your entry. Please check the validity of your five digit zip code.');
     }
-    else { 
-      state.setLat(locationData.latitude);
-      state.setLong(locationData.longitude);
-      state.setElev(locationData.elevation);
-      props.onSubmit(state.lat, state.long, state.elev);
+    else if (locationData.latitude && locationData.longitude && locationData.elevation) { 
+      props.onSubmit(locationData.latitude, locationData.longitude, locationData.elevation);
     }
     setLoading(false);
   };
@@ -78,11 +60,8 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
       console.log(locationData.errorMessage);
       alert('No results found for your entry. Please check the validity of your city/state pair.');
     }
-    else {
-      state.setLat(locationData.latitude);
-      state.setLong(locationData.longitude);
-      state.setElev(locationData.elevation);
-      props.onSubmit(state.lat, state.long, state.elev);
+    else if (locationData.latitude && locationData.longitude && locationData.elevation) {
+      props.onSubmit(locationData.latitude, locationData.longitude, locationData.elevation);
     }
     setLoading(false);
   };

--- a/src/components/TextEntry.tsx
+++ b/src/components/TextEntry.tsx
@@ -8,9 +8,6 @@ import { Controller, useForm } from 'react-hook-form';
 import {getCityStateCoordinates, getZipCoordinates, LocationData} from '../utils/getCoordinates';
 
 interface TextEntryProps {
-  initialLat: number | null;
-  initialLong: number | null;
-  initialElev: number | null;
   onSubmit: (homeLat: number, homeLong: number, homeElev: number) => void;
 }
 interface DataError {
@@ -55,12 +52,7 @@ const TextEntry: React.FC<TextEntryProps> = (props: TextEntryProps) => {
   const { control, handleSubmit } = useForm();
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<DataError>({ showError: false });
-    
-  React.useEffect(() => {
-    state.setLat(props.initialLat);
-    state.setLong(props.initialLong);
-    state.setElev(props.initialElev);
-  }, [props.initialLat, props.initialLong, props.initialElev, state]);
+    ;
   //called when the text entry is determined to be a zip code
   const getZipCodeData = async () => {
     setLoading(true);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -64,9 +64,6 @@ const HomePage: React.FC<RouteComponentProps> = ({history}) => {
             </IonCardHeader>
             <IonCardContent>
               <DeviceLocation
-                initialLat={lat}
-                initialLong={long}
-                initialElev={elev}
                 onSubmit={onLatLongChange}
               ></DeviceLocation>
             </IonCardContent>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -17,20 +17,11 @@ export interface ExportStation {
 } 
 
 const HomePage: React.FC<RouteComponentProps> = ({history}) => {
-  const [lat, setLat] = useState<number>(0);
-  const [long, setLong] = useState<number>(0);
-  const [elev, setElev] = useState<number>(0);
-
   //this function fires when either the "Use My Location" or "Submit" buttons on the homepage are clicked.
   const onLatLongChange =  (newLat: number, newLong: number, newElev: number) => {
-    //the incoming (new) lat/long/elevation are set to the state variables
-    setLat(newLat);
-    setLong(newLong);
-    setElev(newElev);
-    //the same three data types are combined into a string
-    const userLoc = newLat.toString() + ',' + newLong.toString() + ',' + newElev.toString();
+    const userLoc = `${newLat.toString()},${newLong.toString()},${newElev.toString()}`;
     //the string is pushed to the dashboard as part of the url to be used by the next page (results page)
-    history.push('/dashboard/results/' + userLoc);
+    history.push(`/dashboard/results/${userLoc}`);
         
   };
   return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -76,9 +76,6 @@ const HomePage: React.FC<RouteComponentProps> = ({history}) => {
             </IonCardHeader>
             <IonCardContent>
               <TextEntry
-                initialLat={lat}
-                initialLong={long}
-                initialElev={elev}
                 onSubmit={onLatLongChange}
               ></TextEntry>
             </IonCardContent>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@ Some Source code for reference:
 https://stackblitz.com/edit/ionic-react-routing?file=src%2Fpages%2FDashboardPage.tsx
 https://www.sitepoint.com/onclick-html-attribute/
 */
-import React, { useState } from 'react';
+import React from 'react';
 import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonCard, IonCardHeader, IonCardContent, IonCardTitle, IonIcon, IonButtons, IonButton } from '@ionic/react';
 import { helpCircle, } from 'ionicons/icons';
 import { RouteComponentProps } from 'react-router-dom';

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -42,7 +42,6 @@ export interface FrostDatesBySeverity {
 }
 
 const ResultsPage: React.FC<ContainerProps> = ({ match, history }) => { 
-  const [userLatLongElev] = useState<string>(match.params.id);
   const [stationID, setStation] = useState<StationUsed>({stationID: '0', lat: 0, long: 0, elevation: 0, state: '0', city: '0', distance: 0});
   const [springFrostJulian, setSpringFrostJulian] = useState<FrostDates>({light: '0', moderate: '0', severe: '0'});
   const [fallFrostJulian, setFallFrostJulian] = useState<FrostDates>({light: '0', moderate: '0', severe: '0'});
@@ -51,8 +50,9 @@ const ResultsPage: React.FC<ContainerProps> = ({ match, history }) => {
   const [showPopover, setShowPopover] = useState(false);
   const [userElevation, setUserElevation] = useState<number>(0);
     
-  // fetches frost dates after station ID updates
+  // fetches frost dates after station ID updates (from history URL)
   useEffect( () => {
+    const userLatLongElev = match.params.id;
     //split out the lat/long
     const latLong = userLatLongElev.split(',');
     let stationIdx = -1;
@@ -103,7 +103,7 @@ const ResultsPage: React.FC<ContainerProps> = ({ match, history }) => {
       }
       else { alert('Error: The station list is empty!');}
     }
-  }, [userLatLongElev]);
+  }, [match.params.id]);
     
   //these two helper functions are for styling purposes. To convert negative/positive lat and long
   //to North, East, South, or West
@@ -121,7 +121,7 @@ const ResultsPage: React.FC<ContainerProps> = ({ match, history }) => {
         <IonToolbar>
           <div className="app-toolbar">
             <IonButtons className="app-title-button app-left-title-button">
-              <IonButton href="/dashboard">
+              <IonButton routerLink="/dashboard">
                 <IonIcon icon={arrowBack} className="app-icon"> </IonIcon>
               </IonButton>
             </IonButtons>

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -54,14 +54,16 @@ const ResultsPage: React.FC<ContainerProps> = ({ match, history }) => {
   useEffect( () => {
     const userLatLongElev = match.params.id;
     //split out the lat/long
-    const latLong = userLatLongElev.split(',');
+    let lat: string, long: string, elevation: string;
+    [lat, long, elevation] = userLatLongElev.split(',');
     let stationIdx = -1;
+
     //make sure these values are not null or undefined
-    if(latLong[0] && latLong[1] && latLong[0] !== undefined && latLong[1] !== undefined) {
+    if(lat && long) {
       //get a list of stations sorted by distance from the user.
-      const closestStation: Station[] | null = getClosestStationList({lat: parseFloat(latLong[0]), long: parseFloat(latLong[1])});
+      const closestStation: Station[] | null = getClosestStationList({lat: parseFloat(lat), long: parseFloat(long)});
       //Set elevation
-      if(latLong[2] && latLong[2] !== undefined) { setUserElevation(parseFloat(latLong[2])* FEET_TO_METERS); }
+      if(elevation) { setUserElevation(parseFloat(elevation)* FEET_TO_METERS); }
       if(closestStation) {
         //get frost data list
         const frostData: FrostData[] = getFrostData();

--- a/src/utils/getCoordinates.ts
+++ b/src/utils/getCoordinates.ts
@@ -88,7 +88,7 @@ export async function getZipCoordinates(zipCode: string): Promise<LocationData> 
         errorMessage: '',
         latitude: json.records[0].fields.latitude,
         longitude: json.records[0].fields.longitude,
-        elevation: apiElev.elevation
+        elevation: apiElev
       };
     }
   } catch(error){ console.log(error); }

--- a/src/utils/getCoordinates.ts
+++ b/src/utils/getCoordinates.ts
@@ -32,7 +32,7 @@ export interface LocationData {
 
 // gets latitude and longitude for a city-state pair (for example, Eugene, OR)
 // if API returns an error, the LocationData object will have hasError = true
-export async function getCityStateCoordinates(cityState: string, cityName: string, stateCode: string): Promise<LocationData> {
+export async function getCityStateCoordinates(cityName: string, stateCode: string): Promise<LocationData> {
   const cityApiStr = `https://public.opendatasoft.com/api/records/1.0/search/?dataset=cities-and-towns-of-the-united-states&q=name=${cityName}&refine.state=${stateCode}`;
   const data = await fetch(cityApiStr, {
     method: 'GET',

--- a/src/utils/getUserElevation.ts
+++ b/src/utils/getUserElevation.ts
@@ -1,23 +1,19 @@
-interface ElevationData {
-    elevation: number | null;
-}
 // gets elevation for a lat,long variable
 // if API has an error, it will return just the error message
-export async function getElevation(lat: number, long: number): Promise<ElevationData> {
+export async function getElevation(lat: number, long: number): Promise<number | null> {
   //build the string for the get request to usgs
   const apiEndpoint = 'https://ned.usgs.gov/epqs/pqs.php?';
   const data = await fetch((apiEndpoint + 'x=' + long.toString() + '&y=' + lat.toString() + '&units=Feet&output=json'), {
     method: 'GET'
   });
   const apiReturn = await data.json();
-  let results: ElevationData = {
-    elevation: null
-  };
+  let elevation = null;
+
   try{ //get the elevation out of the return from the API call
     if (apiReturn && apiReturn !== undefined){
-      results = { elevation: apiReturn.USGS_Elevation_Point_Query_Service.Elevation_Query.Elevation };
+      elevation = apiReturn.USGS_Elevation_Point_Query_Service.Elevation_Query.Elevation;
     }
   }
   catch{ console.log('Error: ', apiReturn); }
-  return results;
+  return elevation;
 }


### PR DESCRIPTION
- No longer has any observables
- Only ResultsPage still has state variables. This is the only page where components need to re-render when state changes (e.g. new station, frost dates, etc.). Everything else is being passed props or sending data back to the HomePage. which then sends data  to the ResultsPage using history.
- Back button from ResultsPage now uses routerLink instead of href for its back button to HomePage. This prevents a hard reload and the "white screen" that appeared on mobile when going back to HomePage. This change also required me to set UseEffect to update whenever the URL changes.